### PR TITLE
Fix invalid xbmcgui.LOGERROR in Radarr/Sonarr error paths

### DIFF
--- a/script.kodiarr.instant/resources/lib/radarr.py
+++ b/script.kodiarr.instant/resources/lib/radarr.py
@@ -114,7 +114,7 @@ def run():
 
         if lookup.status_code != 200:
             notify("Radarr", "Lookup failed: {}".format(lookup.status_code), xbmcgui.NOTIFICATION_ERROR)
-            log("Radarr lookup failed: {}".format(lookup.text), xbmcgui.LOGERROR)
+            log("Radarr lookup failed: {}".format(lookup.text), xbmc.LOGERROR)
             return
 
         movies = lookup.json()
@@ -127,7 +127,7 @@ def run():
 
         if not movie.get("tmdbId"):
             notify("Radarr", "Invalid lookup result", xbmcgui.NOTIFICATION_ERROR)
-            log("Radarr invalid lookup payload: {}".format(movie), xbmcgui.LOGERROR)
+            log("Radarr invalid lookup payload: {}".format(movie), xbmc.LOGERROR)
             return
 
         if movie.get("id", 0) > 0:
@@ -144,7 +144,7 @@ def run():
                 notify("Radarr", "'{}' already exists. Search triggered.".format(title))
             else:
                 notify("Radarr", "Movie exists, but search failed", xbmcgui.NOTIFICATION_ERROR)
-                log("Radarr command failed: {}".format(cmd.text), xbmcgui.LOGERROR)
+                log("Radarr command failed: {}".format(cmd.text), xbmc.LOGERROR)
             return
 
         payload = {
@@ -179,8 +179,8 @@ def run():
             notify("Radarr", "Added '{}'. Search started.".format(title))
         else:
             notify("Radarr", "Add failed: {}".format(add_resp.status_code), xbmcgui.NOTIFICATION_ERROR)
-            log("Radarr add failed: {}".format(add_resp.text), xbmcgui.LOGERROR)
+            log("Radarr add failed: {}".format(add_resp.text), xbmc.LOGERROR)
 
     except Exception as e:
         notify("Radarr", "Error: {}".format(e), xbmcgui.NOTIFICATION_ERROR)
-        log("Radarr crash: {}".format(e), xbmcgui.LOGERROR)
+        log("Radarr crash: {}".format(e), xbmc.LOGERROR)

--- a/script.kodiarr.instant/resources/lib/sonarr.py
+++ b/script.kodiarr.instant/resources/lib/sonarr.py
@@ -260,7 +260,7 @@ def run():
 
         if lookup.status_code != 200:
             notify("Sonarr", "Lookup failed: {}".format(lookup.status_code), xbmcgui.NOTIFICATION_ERROR)
-            log("Sonarr lookup failed: {}".format(lookup.text), xbmcgui.LOGERROR)
+            log("Sonarr lookup failed: {}".format(lookup.text), xbmc.LOGERROR)
             return
 
         results = lookup.json()
@@ -296,7 +296,7 @@ def run():
 
             if add_resp.status_code != 201:
                 notify("Sonarr", "Add failed: {}".format(add_resp.status_code), xbmcgui.NOTIFICATION_ERROR)
-                log("Sonarr add failed: {}".format(add_resp.text), xbmcgui.LOGERROR)
+                log("Sonarr add failed: {}".format(add_resp.text), xbmc.LOGERROR)
                 return
 
             series_db_id = add_resp.json()["id"]
@@ -318,7 +318,7 @@ def run():
                 notify("Sonarr", "Series search started: {}".format(title))
             else:
                 notify("Sonarr", "Series search failed", xbmcgui.NOTIFICATION_ERROR)
-                log("Sonarr series search failed: {}".format(cmd.text), xbmcgui.LOGERROR)
+                log("Sonarr series search failed: {}".format(cmd.text), xbmc.LOGERROR)
             return
 
         if info["type"] == "season":
@@ -372,11 +372,11 @@ def run():
                 )
             else:
                 notify("Sonarr", "Episode search failed", xbmcgui.NOTIFICATION_ERROR)
-                log("Sonarr episode search failed: {}".format(cmd.text), xbmcgui.LOGERROR)
+                log("Sonarr episode search failed: {}".format(cmd.text), xbmc.LOGERROR)
             return
 
         notify("Sonarr", "Unsupported TV item", xbmcgui.NOTIFICATION_ERROR)
 
     except Exception as e:
         notify("Sonarr", "Error: {}".format(e), xbmcgui.NOTIFICATION_ERROR)
-        log("Sonarr crash: {}".format(e), xbmcgui.LOGERROR)
+        log("Sonarr crash: {}".format(e), xbmc.LOGERROR)


### PR DESCRIPTION
The error-logging calls in the main Radarr and Sonarr flows pass
`xbmcgui.LOGERROR`, which does not exist. The Kodi log-level constants
live in the `xbmc` module, not `xbmcgui`.

`common.log()` forwards the level to `xbmc.log()`, so evaluating
`xbmcgui.LOGERROR` at the call site raises
`AttributeError: module 'xbmcgui' has no attribute 'LOGERROR'`. This
happens on every failure path (failed lookup, add, command, or an
exception): instead of the intended error message the user gets a
script error, and the surrounding `except` then calls
`log(..., xbmcgui.LOGERROR)` again, raising a second uncaught
AttributeError. The happy path is unaffected.

The helper/test functions already use the correct `xbmc.LOGERROR`
(for example radarr.py:28, 45, 51), so this is an inconsistency.

Fix: use `xbmc.LOGERROR` at the affected sites. `xbmc` is already
imported in both files, so no other change is needed.

Affected lines:
- resources/lib/radarr.py: 117, 130, 147, 182, 186
- resources/lib/sonarr.py: 263, 299, 321, 375, 382

Verified on Kodi 22: `xbmcgui.LOGERROR` raises AttributeError,
`xbmc.LOGERROR` is 3, and calling the addon's
`common.log(msg, xbmc.LOGERROR)` works.
