### PR TITLE
Update sonarr.py with seriesType support

### DIFF
--- a/script.kodiarr.instant/resources/lib/sonarr.py
+++ b/script.kodiarr.instant/resources/lib/sonarr.py
@@ -277,6 +277,13 @@ def run():
             should_search_missing = (info["type"] == "tvshow")
 
             payload = dict(series)
+
+            genres_raw = str(series.get("genres", [])).lower()
+            if "anime" in genres_raw:
+                payload["seriesType"] = "anime"
+            else:
+                payload["seriesType"] = "standard"
+                
             payload.update({
                 "qualityProfileId": profile,
                 "rootFolderPath": root,


### PR DESCRIPTION
Hi,

First, thank you for this great and minimalist add-on! I really appreciate the 1-click approach from the context menu.

The Problem:
Currently, when adding an anime to Sonarr via the add-on, it defaults to "seriesType": "standard". In Sonarr, this breaks the absolute ordering and tracking for anime shows (which usually require "seriesType": "anime" to grab properly). Since the add-on is designed to skip prompts, anime users have to manually fix the series type in Sonarr's mass editor afterwards.

Proposed Solution:
During the lookup phase, Sonarr's API already returns the genres array from TVDB/Skyhook (which reliably includes "Anime" for Japanese animation). We can simply read this array before building the payload in sonarr.py (around line 277 in the current main branch) and set the seriesType dynamically.

Here is a working modification that safely checks for the anime genre (case-insensitive) without breaking the current logic for standard shows. I have tested it locally and it works perfectly:



            payload = dict(series)
            
            # --- PROPOSED MODIFICATION ---
            genres_raw = str(series.get("genres", [])).lower()
            if "anime" in genres_raw:
                payload["seriesType"] = "anime"
            else:
                payload["seriesType"] = "standard"
            # -----------------------------

            payload.update({
                "qualityProfileId": profile,
                "rootFolderPath": root,
                "monitored": True,
                "seasons": _build_monitored_seasons(series, info),
                "addOptions": {
                    "searchForMissingEpisodes": should_search_missing
                }
            })

This tiny addition makes the 1-click experience completely seamless for anime watchers without adding any UI clutter or extra settings.

Thanks for considering it!